### PR TITLE
M1 Macbook Pro, timeのうちuserを参照していたのでreal(total)に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ ac9f830ae6cf2299ba293dd4cec3be0d87a88e6a8fbfe5015de6fffd11d79b6e
 - Thinkpad X13 (AMD Ryzen 7 PRO 4750U) 16 worker. Linux + PHP 8.0.2 `abcdef1` => 2m0.772s
 - Mac mini 2018 (Core i7-8700B @ 3.20GHz) 16 worker. macOS catalina + PHP7.4.9 `abcdef` => 0m3.685s
 - Mac mini 2018 (Core i7-8700B @ 3.20GHz) 16 worker. macOS catalina + PHP7.4.9 `abcdef1` => 2m28.340s
-- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abc` => 0m021s
-- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcd` => 0m061s
-- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcde` => 0m626s
-- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcdef` => 0m14.065s
-- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcdef1` => 3m17.91s
+- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abc` => 0m0.023s
+- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcd` => 0m0.067s
+- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcde` => 0m0.707s
+- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcdef` => 0m1.795s
+- Macbook Pro 2020 M1 8 worker. macOS Big Sur + PHP ([php-src:8ffc20](https://github.com/php/php-src/tree/8ffc20ace6c8a59b30aea53e2100aa26e4f1f3ee)) `abcdef1` => 0m25.928s


### PR DESCRIPTION
参考ログ `abcdef1` を worker 1~8 まで順に実行した結果
https://gist.github.com/chatii/a54e954d50b82b4c1a37f279aaa9526a